### PR TITLE
MDBF-1161 Fix links errors

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Check for links error
         run: |
           docker run --rm -t -v $(pwd):/src -w /src lycheeverse/lychee:latest \
-            --base html_site \
+            --root-dir /src/html_site \
             --exclude "(github|gitlab|www.linkedin).com" \
             --exclude "^javascript:" \
             -n -v html_site/**/*.html

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - deploy
+  pull_request:
   workflow_dispatch:  # Allows manual triggering
 
 jobs:
@@ -35,11 +36,13 @@ jobs:
             -n -v html_site/**/*.html
 
       - name: Configure Git
+        if: github.event_name != 'pull_request'
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'github-actions@github.com'
 
       - name: Commit and push if changed
+        if: github.event_name != 'pull_request'
         run: |
           git add html_site/
           git diff --quiet && git diff --staged --quiet || (git commit -m "Build Hugo site [skip ci]" && git push)
@@ -47,6 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to HZ server
+        if: github.event_name != 'pull_request'
         run: |
           # Set up SSH
           mkdir -p ~/.ssh


### PR DESCRIPTION
The fix was already in the `deploy` branch, I cherry-picked the commit.
Took me longer because I had to figure out all this weirdness of mixing branches, where `deploy` has some code, `main` is just another thing. That's for another day.

As a rule of thumb:
- when you manually trigger a worfklow (GitHub Actions), the code for that workflow corresponds to the selected branch.

Added: Build and link errors validation for Pull Requests (like this one).

_PS: make sure the workflow is the same between the two branches._

